### PR TITLE
approve recovery & cancel recovery UI

### DIFF
--- a/src/app/manage-recovery/dashboard/page.tsx
+++ b/src/app/manage-recovery/dashboard/page.tsx
@@ -34,6 +34,13 @@ const initialGuardians: Guardian[] = [
   },
 ];
 
+const safeSigners = [
+  "0x1234567890abcdef1234567890abcdef12345678",
+  "0x1334567890abcdef1234567890abcdef12345678",
+];
+
+const safeAccount = "0xabc.eth";
+
 export default function Dashboard() {
   const recoveryLink = "https://candide.com/recovery/0xabc.eth";
   const hasActiveRecovery = true;
@@ -68,10 +75,13 @@ export default function Dashboard() {
               <RecoverySidebar
                 hasActiveRecovery={hasActiveRecovery}
                 recoveryLink={recoveryLink}
+                safeAccount={safeAccount}
               />
               <RecoveryContent
                 hasActiveRecovery={hasActiveRecovery}
                 guardians={currentGuardians}
+                safeSigners={safeSigners}
+                safeAccount={safeAccount}
               />
             </div>
           </TabsContent>
@@ -81,6 +91,7 @@ export default function Dashboard() {
               <RecoverySidebar
                 hasActiveRecovery={hasActiveRecovery}
                 recoveryLink={recoveryLink}
+                safeAccount={safeAccount}
               />
               <GuardiansContent
                 currentGuardians={currentGuardians}

--- a/src/components/address-section.tsx
+++ b/src/components/address-section.tsx
@@ -1,0 +1,41 @@
+import { STYLES } from "@/constants/styles";
+import { ExternalLinkIcon } from "lucide-react";
+import React from "react";
+
+interface AddressSectionProps {
+  title: string;
+  description: string;
+  addresses: string[];
+}
+
+export default function AddressSection({
+  title,
+  description,
+  addresses,
+}: AddressSectionProps) {
+  return (
+    <div className="space-y-3">
+      <p className={STYLES.modalSectionTitle}>{title}</p>
+      <p className={STYLES.modalSectionDescription}>{description}</p>
+      <div className="space-y-2">
+        {addresses.map((address) => (
+          <div
+            key={address}
+            className="items-center gap-2 bg-terciary inline-flex py-0.5 px-2 rounded-md"
+          >
+            <p className="text-primary font-roboto-mono font-medium text-xs">
+              {address}
+            </p>
+            <ExternalLinkIcon
+              size={12}
+              className="text-primary"
+              onClick={() =>
+                window.open(`https://etherscan.io/address/${address}`)
+              }
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/address-section.tsx
+++ b/src/components/address-section.tsx
@@ -26,6 +26,7 @@ export default function AddressSection({
             <p className="text-primary font-roboto-mono font-medium text-xs">
               {address}
             </p>
+            {/* TODO: CANDIDE-36 - Handle all external links to manage multiple chains */}
             <ExternalLinkIcon
               size={12}
               className="text-primary"

--- a/src/components/approve-recovery-modal-content.tsx
+++ b/src/components/approve-recovery-modal-content.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import AddressSection from "./address-section";
+import { Square, SquareCheckBig } from "lucide-react";
+interface ApproveRecoveryModalContentProps {
+  safeAccount: string;
+  safeSigners: string[];
+  isChecked: boolean;
+  thresholdAchieved: boolean;
+  delayPeriod: number;
+  handleCheckToggle: () => void;
+}
+
+export default function ApproveRecoveryModalContent({
+  safeAccount,
+  safeSigners,
+  isChecked,
+  thresholdAchieved,
+  delayPeriod,
+  handleCheckToggle,
+}: ApproveRecoveryModalContentProps) {
+  return (
+    <div className="space-y-7">
+      <AddressSection
+        title="Safe Address"
+        description="The address of the account that need to be recovered."
+        addresses={[safeAccount]}
+      />
+      <AddressSection
+        title="Safe Signers"
+        description="The public address of the new Safe signers."
+        addresses={safeSigners}
+      />
+      <div
+        className="flex items-center gap-2 cursor-pointer"
+        onClick={handleCheckToggle}
+        role="checkbox"
+        aria-checked={isChecked}
+      >
+        {isChecked ? (
+          <SquareCheckBig size={16} className="text-primary" />
+        ) : (
+          <Square size={16} className="text-primary" />
+        )}
+        {thresholdAchieved && (
+          <span className="text-content-foreground font-roboto-mono text-sm">
+            Start the {delayPeriod}-day delay period now.
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/guardian-list.tsx
+++ b/src/components/guardian-list.tsx
@@ -242,7 +242,7 @@ function GuardiansToBeRemoved({
       </div>
       <div className="grid grid-cols-[1fr,2fr] gap-2">
         <Input readOnly value={nickname} className={STYLES.input} />
-        <div className="flex flex-1 gap-2">
+        <div className="flex flex-1 gap-2 items-center">
           <Input
             readOnly
             value={address}

--- a/src/components/loading-modal.tsx
+++ b/src/components/loading-modal.tsx
@@ -2,19 +2,23 @@ import React from "react";
 import { Dialog, DialogContent, DialogTitle } from "./ui/dialog";
 import LoadingSpinner from "./ui/loading-spinner";
 
+interface LoadingModalProps {
+  loading: boolean;
+  loadingText?: string;
+  setIsloading: (loading: boolean) => void;
+}
+
 export default function LoadingModal({
   loading,
+  loadingText,
   setIsloading,
-}: {
-  loading: boolean;
-  setIsloading: (loading: boolean) => void;
-}) {
+}: LoadingModalProps) {
   return (
     <Dialog open={loading} onOpenChange={() => setIsloading(false)}>
       <DialogContent className="flex flex-col bg-content-background border-none rounded-3xl items-center [&>button]:hidden">
         <LoadingSpinner />
         <DialogTitle className="font-roboto-mono font-normal text-base text-content-foreground opacity-60">
-          Waiting for the transaction signature...
+          {loadingText || "Loading..."}
         </DialogTitle>
       </DialogContent>
     </Dialog>

--- a/src/components/loading-modal.tsx
+++ b/src/components/loading-modal.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { Dialog, DialogContent, DialogTitle } from "./ui/dialog";
+import LoadingSpinner from "./ui/loading-spinner";
+
+export default function LoadingModal({
+  loading,
+  setIsloading,
+}: {
+  loading: boolean;
+  setIsloading: (loading: boolean) => void;
+}) {
+  return (
+    <Dialog open={loading} onOpenChange={() => setIsloading(false)}>
+      <DialogContent className="flex flex-col bg-content-background border-none rounded-3xl items-center [&>button]:hidden">
+        <LoadingSpinner />
+        <DialogTitle className="font-roboto-mono font-normal text-base text-content-foreground opacity-60">
+          Waiting for the transaction signature...
+        </DialogTitle>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/modal.tsx
+++ b/src/components/modal.tsx
@@ -14,7 +14,7 @@ interface ModalProps {
   isOpen: boolean;
   title: string;
   description?: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
   currentStep: number;
   totalSteps: number;
   nextLabel?: string;
@@ -69,7 +69,7 @@ export function Modal({
               )}
             </DialogHeader>
           </div>
-          <div className="flex-1">{children}</div>
+          {children && <div className="flex-1">{children}</div>}
           <DialogFooter
             className={cn(isProgress ? "sm:justify-end" : "sm:justify-center")}
           >

--- a/src/components/new-guardians-list.tsx
+++ b/src/components/new-guardians-list.tsx
@@ -86,7 +86,7 @@ export default function NewGuardianList({
               className={STYLES.input}
             />
           )}
-          <div className="flex flex-1 gap-2">
+          <div className="flex flex-1 gap-2 items-center">
             <Input
               readOnly
               value={guardian.address}
@@ -137,7 +137,7 @@ export default function NewGuardianList({
                 className={STYLES.input}
               />
             )}
-            <div className="flex flex-1 gap-2">
+            <div className="flex flex-1 gap-2 items-center">
               <Input
                 placeholder="Address..."
                 value={newGuardian.address}

--- a/src/components/recovery-content.tsx
+++ b/src/components/recovery-content.tsx
@@ -9,6 +9,7 @@ import { Button } from "./ui/button";
 import { Modal } from "./modal";
 import LoadingModal from "./loading-modal";
 import ApproveRecoveryModalContent from "./approve-recovery-modal-content";
+import { useToast } from "@/hooks/use-toast";
 
 interface RecoveryContentProps {
   hasActiveRecovery: boolean;
@@ -27,12 +28,34 @@ export default function RecoveryContent({
   const [loading, setIsloading] = useState(false);
   const [isChecked, setIsChecked] = useState(false);
 
+  const { toast } = useToast();
+
   // MOCKED LOADING  UNTIL INTEGRATION
   const handleApproveRecovery = () => {
     setIsOpen(false);
     setIsloading(true);
     setTimeout(() => {
       setIsloading(false);
+      if (thresholdAchieved && isChecked) {
+        toast({
+          title: "Recovery executed.",
+          description: "Delay Period has started.",
+        });
+        return;
+      }
+      if (!thresholdAchieved) {
+        toast({
+          title: "Recovery approved.",
+          description:
+            "Waiting for other guardians to approve before starting the delay period.",
+        });
+        return;
+      }
+      toast({
+        title: "Recovery approved.",
+        description: "The threshold was achieved. Click to start delay period.",
+      });
+      return;
     }, 4000);
   };
 

--- a/src/components/recovery-content.tsx
+++ b/src/components/recovery-content.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { STYLES } from "@/constants/styles";
 import { Guardian, GuardianList } from "./guardian-list";
 import PressableIcon from "./pressable-icon";
@@ -6,16 +6,42 @@ import { ExternalLink } from "lucide-react";
 import { cn } from "@/lib/utils";
 import EmptyActiveRecovery from "./empty-active-recovery";
 import { Button } from "./ui/button";
+import { Modal } from "./modal";
+import LoadingModal from "./loading-modal";
+import ApproveRecoveryModalContent from "./approve-recovery-modal-content";
 
 interface RecoveryContentProps {
   hasActiveRecovery: boolean;
   guardians: Guardian[];
+  safeSigners: string[];
+  safeAccount: string;
 }
 
 export default function RecoveryContent({
   hasActiveRecovery,
   guardians,
+  safeSigners,
+  safeAccount,
 }: RecoveryContentProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [loading, setIsloading] = useState(false);
+  const [isChecked, setIsChecked] = useState(false);
+
+  // MOCKED LOADING  UNTIL INTEGRATION
+  const handleApproveRecovery = () => {
+    setIsOpen(false);
+    setIsloading(true);
+    setTimeout(() => {
+      setIsloading(false);
+    }, 4000);
+  };
+
+  const handleCheckToggle = () => {
+    setIsChecked((prev) => !prev);
+  };
+
+  const thresholdAchieved = true;
+
   return (
     <div className="col-span-2">
       <div className="p-6 bg-content-background shadow-lg rounded-xl">
@@ -46,16 +72,16 @@ export default function RecoveryContent({
           <>
             <div className="flex-col gap-1 inline-flex">
               <p className={STYLES.label}>SAFE SIGNERS</p>
-              {guardians.map((guardian) => (
+              {safeSigners.map((address) => (
                 <div
-                  key={guardian.nickname}
+                  key={address}
                   className={cn(
                     STYLES.textWithBorder,
                     "inline-flex items-center gap-2"
                   )}
                   style={STYLES.textWithBorderOpacity}
                 >
-                  <span>{guardian.address}</span>
+                  <span>{address}</span>
                   <PressableIcon
                     icon={ExternalLink}
                     onClick={() => {}}
@@ -72,13 +98,38 @@ export default function RecoveryContent({
               <Button className="text-xs font-bold px-3 py-2 rounded-xl">
                 Start Delay Period
               </Button>
-              <Button className="text-xs font-bold px-3 py-2 rounded-xl">
+              <Button
+                className="text-xs font-bold px-3 py-2 rounded-xl"
+                onClick={() => setIsOpen(true)}
+              >
                 Approve Recovery
               </Button>
             </div>
             <span className="text-xs flex justify-end text-[10px] opacity-60">
               Only Guardians can approve this recovery request.
             </span>
+            <Modal
+              title="Approve Recovery Request"
+              description="A recovery request has been started and your approval is required to proceed with the recovery. Review the details below and confirm if you approve."
+              currentStep={2}
+              isOpen={isOpen}
+              totalSteps={1}
+              onClose={() => setIsOpen(false)}
+              onNext={handleApproveRecovery}
+              onBack={() => setIsOpen(false)}
+              nextLabel="Sign and Approve"
+              backLabel="Cancel"
+            >
+              <ApproveRecoveryModalContent
+                handleCheckToggle={handleCheckToggle}
+                delayPeriod={3}
+                isChecked={isChecked}
+                safeAccount={safeAccount}
+                safeSigners={safeSigners}
+                thresholdAchieved={thresholdAchieved}
+              />
+            </Modal>
+            <LoadingModal loading={loading} setIsloading={setIsloading} />
           </>
         ) : (
           <EmptyActiveRecovery />

--- a/src/components/recovery-content.tsx
+++ b/src/components/recovery-content.tsx
@@ -31,7 +31,9 @@ export default function RecoveryContent({
 
   const { toast } = useToast();
 
-  // MOCKED LOADING  UNTIL INTEGRATION
+  const thresholdAchieved = true;
+
+  //TODO: CANDIDE-32 - MOCKED LOADING  UNTIL INTEGRATION
   const handleApproveRecovery = () => {
     setIsOpen(false);
     setApproveLoading(true);
@@ -63,8 +65,6 @@ export default function RecoveryContent({
   const handleCheckToggle = () => {
     setIsChecked((prev) => !prev);
   };
-
-  const thresholdAchieved = true;
 
   return (
     <div className="col-span-2">

--- a/src/components/recovery-content.tsx
+++ b/src/components/recovery-content.tsx
@@ -25,7 +25,8 @@ export default function RecoveryContent({
   safeAccount,
 }: RecoveryContentProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [loading, setIsloading] = useState(false);
+  const [approveLoading, setApproveLoading] = useState(false);
+  const [finishLoading, setFinishLoading] = useState(false);
   const [isChecked, setIsChecked] = useState(false);
 
   const { toast } = useToast();
@@ -33,9 +34,9 @@ export default function RecoveryContent({
   // MOCKED LOADING  UNTIL INTEGRATION
   const handleApproveRecovery = () => {
     setIsOpen(false);
-    setIsloading(true);
+    setApproveLoading(true);
     setTimeout(() => {
-      setIsloading(false);
+      setApproveLoading(false);
       if (thresholdAchieved && isChecked) {
         toast({
           title: "Recovery executed.",
@@ -152,7 +153,15 @@ export default function RecoveryContent({
                 thresholdAchieved={thresholdAchieved}
               />
             </Modal>
-            <LoadingModal loading={loading} setIsloading={setIsloading} />
+            <LoadingModal
+              loading={approveLoading || finishLoading}
+              setIsloading={setApproveLoading || setFinishLoading}
+              loadingText={
+                approveLoading
+                  ? "Waiting for the transaction signature..."
+                  : "Executing recovery..."
+              }
+            />
           </>
         ) : (
           <EmptyActiveRecovery />

--- a/src/components/recovery-sidebar.tsx
+++ b/src/components/recovery-sidebar.tsx
@@ -8,11 +8,13 @@ import { Button } from "./ui/button";
 interface RecoverySideBarProps {
   hasActiveRecovery: boolean;
   recoveryLink: string;
+  safeAccount: string;
 }
 
 export default function RecoverySidebar({
   hasActiveRecovery,
   recoveryLink,
+  safeAccount,
 }: RecoverySideBarProps) {
   const thresholdAchieved = true;
   const delayPeriodStarted = true;
@@ -33,7 +35,7 @@ export default function RecoverySidebar({
         style={STYLES.textWithBorderOpacity}
         className="flex items-center gap-3 opacity-60 border-b border-opacity-30 pb-2 mb-6"
       >
-        <p className="text-2xl font-roboto-mono">0xabc.eth</p>
+        <p className="text-2xl font-roboto-mono">{safeAccount}</p>
         <PressableIcon icon={ExternalLink} onClick={() => {}} size={18} />
       </div>
       {hasActiveRecovery && (

--- a/src/components/recovery-sidebar.tsx
+++ b/src/components/recovery-sidebar.tsx
@@ -4,6 +4,10 @@ import { ExternalLink } from "lucide-react";
 import { RecoveryLinkSection } from "./recovery-link-section";
 import PressableIcon from "./pressable-icon";
 import { Button } from "./ui/button";
+import { Modal } from "./modal";
+import { useState } from "react";
+import { useToast } from "@/hooks/use-toast";
+import LoadingModal from "./loading-modal";
 
 interface RecoverySideBarProps {
   hasActiveRecovery: boolean;
@@ -16,9 +20,27 @@ export default function RecoverySidebar({
   recoveryLink,
   safeAccount,
 }: RecoverySideBarProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isWaitingTransaction, setIsWaitingTransaction] = useState(false);
+
+  const { toast } = useToast();
+
   const thresholdAchieved = true;
   const delayPeriodStarted = true;
   const delayPeriodEnded = false;
+
+  const handleCancelRecovery = () => {
+    setIsOpen(false);
+    setIsWaitingTransaction(true);
+    setTimeout(() => {
+      setIsWaitingTransaction(false);
+      toast({
+        title: "Recovery Request canceled.",
+        description:
+          "All approvals have been revoked, and the process is now terminated.",
+      });
+    }, 4000);
+  };
 
   return (
     <div className="col-span-1">
@@ -47,9 +69,29 @@ export default function RecoverySidebar({
           <p className="text-xs font-medium opacity-60 my-2">
             Account owners can cancel this request at any time.
           </p>
-          <Button className="font-bold text-xs rounded-xl">Cancel</Button>
+          <Button
+            className="font-bold text-xs rounded-xl"
+            onClick={() => setIsOpen(true)}
+          >
+            Cancel
+          </Button>
         </>
       )}
+      <Modal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        currentStep={1}
+        totalSteps={1}
+        nextLabel="Cancel Request"
+        onNext={handleCancelRecovery}
+        title="Cancel Recovery Request?"
+        description="By canceling this recovery request, the process will be stopped immediately. Guardians will no longer be able to approve it, and the request cannot be executed. Are you sure you want to cancel?"
+      />
+      <LoadingModal
+        loading={isWaitingTransaction}
+        setIsloading={setIsWaitingTransaction}
+        loadingText="Canceling recovery..."
+      />
     </div>
   );
 }

--- a/src/constants/styles.ts
+++ b/src/constants/styles.ts
@@ -10,4 +10,8 @@ export const STYLES = {
     "text-xs font-bold text-foreground opacity-30"
   ),
   input: "bg-background text-sm border-none focus:ring-primary",
+  modalSectionTitle:
+    "text-base font-bold font-roboto-mono text-content-foreground",
+  modalSectionDescription:
+    "text-sm font-roboto-mono text-content-foreground opacity-60",
 } as const;


### PR DESCRIPTION
closes [CANDIDE-27](https://linear.app/bleu-builders/issue/CANDIDE-27/approve-recovery)
closes [CANDIDE-28](https://linear.app/bleu-builders/issue/CANDIDE-28/cancel-recovery-ui)

description:
- create approve recovery modal
- create cancel request modal
- create loading modal

Demo:

https://github.com/user-attachments/assets/845772f0-521a-4001-9bbb-5cfc6fee4020

