### PR TITLE
Work on feedbacks

### DIFF
--- a/src/app/manage-recovery/dashboard/page.tsx
+++ b/src/app/manage-recovery/dashboard/page.tsx
@@ -80,7 +80,10 @@ export default function Dashboard() {
   const newThreshold = newThresholdFromParams ?? newThresholdFromWallet;
   const chainId = chainIdFromParams ?? chainIdFromWallet;
 
-  const { owners: safeSigners } = useSrmData(safeAddress, chainId);
+  const { owners: safeSigners, safeThreshold } = useSrmData(
+    safeAddress,
+    chainId
+  );
 
   const { delayPeriod: delayPeriodStr } = useSocialRecoveryModule({
     safeAddress,
@@ -183,6 +186,7 @@ export default function Dashboard() {
                   />
                   <RecoveryContent
                     safeSigners={safeSigners}
+                    safeThreshold={safeThreshold}
                     safeAddress={safeAddress}
                     newOwners={newOwners}
                     newThreshold={newThreshold}
@@ -191,6 +195,7 @@ export default function Dashboard() {
                     approvalsInfo={approvalsInfo}
                     recoveryInfo={recoveryInfo}
                     resetQueries={resetQueries}
+                    chainId={chainId ?? 1}
                   />
                 </div>
               </TabsContent>

--- a/src/components/address-section.tsx
+++ b/src/components/address-section.tsx
@@ -1,7 +1,10 @@
 "use client";
 import { STYLES } from "@/constants/styles";
+import { getEtherscanAddressLink } from "@/utils/get-etherscan-link";
 import { ExternalLinkIcon } from "lucide-react";
 import React from "react";
+import { useAccount } from "wagmi";
+import Link from "next/link";
 
 interface AddressSectionProps {
   title: string;
@@ -14,6 +17,8 @@ export default function AddressSection({
   description,
   addresses,
 }: AddressSectionProps) {
+  const { chainId } = useAccount();
+
   return (
     <div className="space-y-3">
       <p className={STYLES.modalSectionTitle}>{title}</p>
@@ -22,22 +27,24 @@ export default function AddressSection({
       )}
       <div className="inline-flex flex-col space-y-2">
         {addresses.map((address) => (
-          <div
+          <Link
             key={address}
-            className="items-center gap-2 bg-terciary inline-flex justify-between py-0.5 px-2 rounded-md"
+            href={getEtherscanAddressLink(chainId ?? 1, address)}
+            target="_blank"
           >
-            <p className="text-primary font-roboto-mono font-medium text-xs">
-              {address}
-            </p>
-            {/* TODO: CANDIDE-36 - Handle all external links to manage multiple chains */}
-            <ExternalLinkIcon
-              size={12}
-              className="text-primary"
-              onClick={() =>
-                window.open(`https://etherscan.io/address/${address}`)
-              }
-            />
-          </div>
+            <div
+              key={address}
+              className="items-center gap-2 bg-terciary inline-flex justify-between py-0.5 px-2 rounded-md hover:cursor-pointer"
+            >
+              <p className="text-primary font-roboto-mono font-medium text-xs">
+                {address}
+              </p>
+              <ExternalLinkIcon
+                size={12}
+                className="text-primary hover:font-bold"
+              />
+            </div>
+          </Link>
         ))}
       </div>
     </div>

--- a/src/components/chain-selector.tsx
+++ b/src/components/chain-selector.tsx
@@ -1,0 +1,65 @@
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+} from "@/components/ui/select";
+import useHashParams from "@/hooks/useHashParams";
+import { ChainIcon } from "connectkit";
+import { useEffect } from "react";
+import { useAccount, useChains } from "wagmi";
+
+export const ChainSelector = ({
+  chainId,
+  setChainId,
+}: {
+  chainId: string;
+  setChainId: (value: string) => void;
+}) => {
+  const chains = useChains();
+
+  const { chainId: connectedChainId } = useAccount();
+  const { chainId: linkChainId } = useHashParams();
+
+  useEffect(() => {
+    if (linkChainId) {
+      console.log("a", linkChainId);
+      setChainId(String(linkChainId));
+      return;
+    }
+    if (connectedChainId) {
+      console.log("b", connectedChainId);
+      setChainId(String(connectedChainId));
+    }
+  }, [linkChainId, connectedChainId, setChainId]);
+
+  return (
+    <Select
+      value={chainId}
+      onValueChange={(value: string) => {
+        if (value) setChainId(value);
+      }}
+    >
+      <SelectTrigger className="w-fit h-fit border-0 rounded-lg border-solid p-1 bg-background text-foreground focus:ring-0 focus:outline-none hover:bg-terciary">
+        <ChainIcon id={Number(chainId)} size={24} />
+      </SelectTrigger>
+      <SelectContent className="bg-background flex flex-col justify-start items-start p-0 m-0 rounded-lg border-terciary border-[1px] border-solid top-2">
+        <SelectGroup className="items-start justify-start w-full rounded-lg">
+          {chains.map((chain) => (
+            <SelectItem
+              key={chain.id}
+              className="px-0 w-full justify-start items-start hover:bg-content-background hover:cursor-pointer"
+              value={chain.id.toString()}
+            >
+              <div className="pl-1 pr-3 flex gap-2 items-start justify-start">
+                <ChainIcon id={chain.id} size={24} />
+                {chain.name}
+              </div>
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  );
+};

--- a/src/components/guardian-list.tsx
+++ b/src/components/guardian-list.tsx
@@ -27,6 +27,7 @@ interface GuardianListProps {
   onRemoveGuardian?: (guardian: NewAddress) => void;
   onOpenGuardianModal?: () => void;
   resetQueries: () => void;
+  linkChainId?: number;
 }
 
 const totalSteps = 3;
@@ -37,6 +38,7 @@ export function GuardianList({
   onRemoveGuardian,
   onOpenGuardianModal,
   resetQueries,
+  linkChainId,
 }: GuardianListProps) {
   const [isRemoveModalOpen, setIsRemoveModalOpen] = useState(false);
   const [isLastGuardianModalOpen, setIsLastGuardianModalOpen] = useState(false);
@@ -44,7 +46,8 @@ export function GuardianList({
   const [currentStep, setCurrentStep] = useState(1);
   const [threshold, setThreshold] = useState(1);
 
-  const { chainId } = useAccount();
+  const { chainId: connectedChainId } = useAccount();
+  const chainId = linkChainId ?? connectedChainId;
 
   const {
     trigger: revokeGuardians,
@@ -197,6 +200,7 @@ export function GuardianList({
               guardian={guardian}
               isNewGuardianList={isNewGuardianList}
               onRemoveGuardian={() => handleRemoveClick(guardian)}
+              chainId={chainId}
             />
           ))}
         </div>

--- a/src/components/guardian-row.tsx
+++ b/src/components/guardian-row.tsx
@@ -4,21 +4,20 @@ import PressableIcon from "./pressable-icon";
 import { Button } from "./ui/button";
 import Link from "next/link";
 import { getEtherscanAddressLink } from "@/utils/get-etherscan-link";
-import { useAccount } from "wagmi";
 
 interface GuardianRowProps {
   guardian: NewAddress;
   isNewGuardianList?: boolean;
   onRemoveGuardian: (guardian: NewAddress) => void;
+  chainId?: number;
 }
 
 export function GuardianRow({
   guardian,
   isNewGuardianList,
   onRemoveGuardian,
+  chainId,
 }: GuardianRowProps) {
-  const { chainId } = useAccount();
-
   return (
     <div className="grid grid-cols-[1fr,3fr,1fr] items-center py-2 px-3 bg-background rounded-lg">
       <div className="text-xs text-foreground opacity-60 font-medium font-roboto-mono">

--- a/src/components/search-input.tsx
+++ b/src/components/search-input.tsx
@@ -1,17 +1,23 @@
 "use client";
 
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { Search, Loader2 } from "lucide-react";
 import { Input } from "./ui/input";
 import { useSearchStore } from "@/stores/useSearchStore";
+import { ChainSelector } from "./chain-selector";
 
 const SearchInput = () => {
+  const [chainId, setChainId] = useState<string>("1");
   const inputRef = useRef<HTMLInputElement>(null);
   const [isFocused, setIsFocused] = useState(false);
 
+  useEffect(() => {
+    console.log({ chainId });
+  }, [chainId]);
+
   const { isLoading, searchValue, setSearchValue, handleSearch } =
-    useSearchStore();
+    useSearchStore({ chainId: Number(chainId) });
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -53,6 +59,7 @@ const SearchInput = () => {
           }
           disabled={isLoading}
         />
+        <ChainSelector chainId={chainId} setChainId={setChainId} />
       </div>
     </form>
   );

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}

--- a/src/constants/styles.ts
+++ b/src/constants/styles.ts
@@ -4,7 +4,10 @@ export const STYLES = {
   textWithBorder:
     "border px-3 opacity-60 text-sm font-medium font-roboto-mono rounded-s",
   label: "text-xs font-roboto-mono font-bold",
-  textWithBorderOpacity: { borderColor: "rgba(255, 255, 255, 0.08)" },
+  textWithBorderOpacity: {
+    borderColor: "rgba(255, 255, 255, 0.08)",
+    padding: "4px",
+  },
   baseTab: cn(
     "py-2 px-4 rounded-xl",
     "text-xs font-bold text-foreground opacity-30"

--- a/src/hooks/useSrmData.ts
+++ b/src/hooks/useSrmData.ts
@@ -37,7 +37,15 @@ export function useSrmData(safeAddress?: Address, chainId?: number) {
         throw new Error("Account, srm or client not available");
       }
 
-      if (!srm) return { guardians: [] };
+      if (!srm)
+        return {
+          guardians: [],
+          owners: (await publicClient.readContract({
+            address: addressToFetch,
+            abi: safeWalletAbi,
+            functionName: "getOwners",
+          })) as Address[],
+        };
 
       const results = await publicClient.multicall({
         contracts: [

--- a/src/hooks/useSrmData.ts
+++ b/src/hooks/useSrmData.ts
@@ -16,6 +16,7 @@ export interface RecoveryInfo {
 
 export interface SrmData {
   owners?: Address[];
+  safeThreshold?: number;
   guardians?: Address[];
   recoveryInfo?: RecoveryInfo;
   threshold?: number;
@@ -37,15 +38,33 @@ export function useSrmData(safeAddress?: Address, chainId?: number) {
         throw new Error("Account, srm or client not available");
       }
 
-      if (!srm)
-        return {
-          guardians: [],
-          owners: (await publicClient.readContract({
-            address: addressToFetch,
-            abi: safeWalletAbi,
-            functionName: "getOwners",
-          })) as Address[],
-        };
+      const safeWalletCalls = [
+        {
+          address: addressToFetch,
+          abi: safeWalletAbi,
+          functionName: "getOwners",
+        },
+        {
+          address: addressToFetch,
+          abi: safeWalletAbi,
+          functionName: "getThreshold",
+        },
+      ];
+
+      if (!srm) {
+        const results = await publicClient.multicall({
+          contracts: safeWalletCalls,
+        });
+
+        const output = {} as SrmData;
+
+        if (results[0].status === "success")
+          output.owners = results[0].result as Address[];
+        if (results[1].status === "success")
+          output.safeThreshold = Number(results[1].result);
+        output.guardians = [];
+        return output;
+      }
 
       const results = await publicClient.multicall({
         contracts: [
@@ -53,6 +72,11 @@ export function useSrmData(safeAddress?: Address, chainId?: number) {
             address: addressToFetch,
             abi: safeWalletAbi,
             functionName: "getOwners",
+          },
+          {
+            address: addressToFetch,
+            abi: safeWalletAbi,
+            functionName: "getThreshold",
           },
           {
             address: srm.moduleAddress as Address,
@@ -80,17 +104,19 @@ export function useSrmData(safeAddress?: Address, chainId?: number) {
       if (results[0].status === "success")
         output.owners = results[0].result as Address[];
       if (results[1].status === "success")
-        output.guardians = results[1].result as Address[];
+        output.safeThreshold = Number(results[1].result);
       if (results[2].status === "success")
-        output.threshold = Number(results[2].result);
+        output.guardians = results[2].result as Address[];
       if (results[3].status === "success")
+        output.threshold = Number(results[3].result);
+      if (results[4].status === "success")
         output.recoveryInfo = {
           guardiansApprovalCount: Number(
-            results[3].result.guardiansApprovalCount
+            results[4].result.guardiansApprovalCount
           ),
-          newThreshold: Number(results[3].result.guardiansApprovalCount),
-          executeAfter: Number(results[3].result.executeAfter),
-          newOwners: results[3].result.newOwners,
+          newThreshold: Number(results[4].result.guardiansApprovalCount),
+          executeAfter: Number(results[4].result.executeAfter),
+          newOwners: results[4].result.newOwners,
         } as RecoveryInfo;
 
       return output;

--- a/src/stores/useSearchStore.ts
+++ b/src/stores/useSearchStore.ts
@@ -2,19 +2,19 @@ import { useToast } from "@/hooks/use-toast";
 import { useLoadingContext } from "@/providers/loading";
 import { createFinalUrl, isValidLink } from "@/utils/recovery-link";
 import { useState } from "react";
-import { useAccount, usePublicClient } from "wagmi";
+import { usePublicClient } from "wagmi";
 import { Address, isAddress } from "viem";
 import { useSocialRecoveryModule } from "@/hooks/use-social-recovery-module";
 import { socialRecoveryModuleAbi } from "@/utils/abis/socialRecoveryModuleAbi";
 
-export const useSearchStore = () => {
+export const useSearchStore = ({ chainId }: { chainId: number }) => {
   const [searchValue, setSearchValue] = useState("");
   const { isLoading, setIsLoading } = useLoadingContext();
   const { toast } = useToast();
 
-  const publicClient = usePublicClient();
-  const { chainId } = useAccount();
+  const publicClient = usePublicClient({ chainId });
   const { srm } = useSocialRecoveryModule({
+    chainId,
     safeAddress: isAddress(searchValue) ? searchValue : undefined,
   });
 


### PR DESCRIPTION
Feedbacks worked:

1. During the finalization screen, we should show the old signer and the new signer during the finalize recovery screen. So that anyone (owners, guardians) can see the new updated state of the wallet before they finilize.
Currently it only shows the old signer only

2. The search bar is missing the network information of the safe. If I paste in a safe address on optimism, it will return no address found. I am guessing it's searching on another network other than on optimism mainnet. We should have a network drop down next to the search bar so that anyone without connecting their wallet can use the search bar
 
3. Great work on this screen! There's one small detail: when I click on the address of the safe account or the signer, the etherscan link goes to ethereum mainnet instead of the network where the safe resides (optimism mainnet in my case) 
 
4. For some reason I can no longer add a guardian and go the next step. I am connected with my Safe.
The error in the console is: Error: [validateNewGuardian] missing owners